### PR TITLE
fix(strm-2387): use api instead of implementation dependency for sl4j

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -14,9 +14,9 @@ plugins {
 dependencies {
     implementation("io.strmprivacy.schemas:schema-common:2.0.1")
     implementation("org.apache.avro:avro:1.11.0")
-    implementation("org.slf4j:slf4j-api:$slf4jVersion")
     implementation("com.fasterxml.jackson.core:jackson-databind:2.14.2")
 
+    api("org.slf4j:slf4j-api:$slf4jVersion")
     api("org.eclipse.jetty:jetty-client:$jettyVersion")
     api("org.eclipse.jetty.http2:http2-client:$jettyVersion")
     api("org.eclipse.jetty.http2:http2-http-client-transport:$jettyVersion")


### PR DESCRIPTION
Fixes #10 